### PR TITLE
[Fix] popping to empty stack

### DIFF
--- a/Transitions.cs
+++ b/Transitions.cs
@@ -8,7 +8,7 @@ namespace UnityNavigator
 		public static void Instant(GameObject from, GameObject to, Action onComplete = null)
 		{
 			if (from != null) from.SetActive(false);
-			to.SetActive(true);
+			if (to != null) to.SetActive(true);
 			if (onComplete != null) onComplete();
 		}
 	}

--- a/ViewStack.cs
+++ b/ViewStack.cs
@@ -76,7 +76,7 @@ namespace UnityNavigator
 
 		public void Push(string newScreenId, Action<GameObject> initView = null, ViewTransition transition = null)
 		{
-			if (!isInitialized) throw new Exception("ViewStack is not yet initialized. Listen for OnInitialized before you start navigating");
+			if (!isInitialized) throw new Exception("ViewStack is not yet initialized.");
 
 			if (transitionIsInProgress)
 			{
@@ -132,11 +132,14 @@ namespace UnityNavigator
 
 			var oldView = oldTopViewEntry != null ? oldTopViewEntry.View : null;
 			transitionIsInProgress = true;
-			transition(oldView, TopViewEntry.View, () =>
+			transition(oldView, TopViewEntry != null ? TopViewEntry.View : null, () =>
 			{
 				// notify the new view that transition has completed
-				TopViewEntry.NotifyView<ITransitionCompleteHandler>(
-					t => t.HandleTransitionComplete());
+				if (TopViewEntry != null)
+				{
+					TopViewEntry.NotifyView<ITransitionCompleteHandler>(
+						t => t.HandleTransitionComplete());
+				}
 
 				if (OnTransitionComplete != null)
 				{


### PR DESCRIPTION
Now popping back to an empty stack will not cause a null reference exception